### PR TITLE
Adds missing sortBy argument

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -249,7 +249,7 @@ var sortNodes = function(tree, sortBy){
     for (var i = 0; i < tree.length; i++) {
         var node = tree[i];
         if(node.children){
-            node.children = sortNodes(node.children);
+            node.children = sortNodes(node.children, sortBy);
         }
     }
     return tree;
@@ -459,7 +459,7 @@ var getNav = function(navName, config, files){
     }
 
     if(sortBy){
-        nodes = sortNodes(nodes);
+        nodes = sortNodes(nodes, sortBy);
     }
 
     nodes = setFileObjectReferences(nodes, files, pathProperty, childrenProperty, navName);


### PR DESCRIPTION
Hi Carl, this should fix the `sortNodes` method. A custom `sortBy` method would not be used otherwise.
