### PR TITLE
Allow to use values of various types for fieldValue option

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -372,12 +372,14 @@ var filterFiles = function(files, key, val){
         var file = files[fileKey],
             groups = file[key];
 
-        if(typeof groups === 'string'){
+        if(groups instanceof Array && typeof val === 'string') {
+            if(groups && groups.indexOf(val) !== -1){
+                out[fileKey] = file;
+            }
+        }else{
             if(groups === val){
                 out[fileKey] = file;
             }
-        } else if(groups && groups.indexOf(val) !== -1){
-            out[fileKey] = file;
         }
     }
     return out;


### PR DESCRIPTION
It seems to be useful to use different types for `fieldValue` option. It allows to use simple boolean flags in posts instead of artificial strings like `"true"`. The following becomes available with the PR:
```
---
show_in_menu: true
---
# The post!
```