### PR TITLE
Fix: Invalid JSON in CLI Usage example

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -16,7 +16,7 @@
   "plugins": {
     "metalsmith-navigation": {
         "navConfigs": {},
-        "navSettings": {},
+        "navSettings": {}
     }
   }
 }


### PR DESCRIPTION
Running metalsmith results in:
`Metalsmith · it seems like metalsmith.json is malformed.`