### PR TITLE
added option cleanurls and mergeIndexWithParentDir

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -102,7 +102,9 @@ var navConfigs = {
         childrenProperty: 'nav_children',
 
         /*
-        * find index in folder and merge it with parent folder
+        * find index.md in folder and merge it with parent folder. it is used also because plugin metalsmith-clean-urls
+        * eg: you have folder `about` and inside this folder is file `index.md`. in nav will be then only file `about/index.html` and no folder `about`
+        * also if you want to use this option make option `mergeMatchingFilesAndDirs` = false
         */
         mergeIndexWithParentDir: false,
         

--- a/Readme.md
+++ b/Readme.md
@@ -102,6 +102,11 @@ var navConfigs = {
         childrenProperty: 'nav_children',
 
         /*
+        * find index in folder and merge it with parent folder
+        */
+        mergeIndexWithParentDir: false,
+        
+        /*
         * if a file and sibling dir have matching names the file will be used as the parent in the nav tree
         * ex: /foo /foo.html
         */
@@ -111,6 +116,11 @@ var navConfigs = {
         * if ALL dirs should be included as nav nodes
         */
         includeDirs: false,
+
+        /*
+        * should be set to true if you are using plugin metalsmith-clean-urls
+        */
+        cleanUrls: false,
     },
 
     // ... any number of navConfigs may be created

--- a/lib/index.js
+++ b/lib/index.js
@@ -97,7 +97,9 @@ var NAV_CONFIG_DEFAULT = {
     childrenProperty: 'nav_children',
 
     /*
-    * find index in folder and merge it with parent folder
+    * find index.md in folder and merge it with parent folder. it is used also because plugin metalsmith-clean-urls
+    * eg: you have folder `about` and inside this folder is file `index.md`. in nav will be then only file `about/index.html` and no folder `about`
+    * also if you want to use this option make option `mergeMatchingFilesAndDirs` = false
     */
     mergeIndexWithParentDir: false,
     

--- a/lib/index.js
+++ b/lib/index.js
@@ -97,6 +97,11 @@ var NAV_CONFIG_DEFAULT = {
     childrenProperty: 'nav_children',
 
     /*
+    * find index in folder and merge it with parent folder
+    */
+    mergeIndexWithParentDir: false,
+    
+    /*
     * if a file and sibling dir have matching names the file will be used as the parent in the nav tree
     * ex: /foo /foo.html
     */
@@ -336,6 +341,43 @@ var mergeFileDirs = function(tree){
 };
 
 /**
+* Find index in dirs and merge it with parent folder
+* @method mergeIndexWithDir
+* @param {Array} tree - Tree of nodes to act on.
+* @return {Array} converted array (same obj as tree param)
+*/
+var mergeIndexWithDir = function(tree){
+    
+        var merge = function(siblings){
+            for (var i = siblings.length - 1; i >= 0; i--){
+                var node = siblings[i];
+                if(node.type === 'dir' && node.children.length){
+                    for(var j = node.children.length - 1; j >= 0; j--){
+                        var child = node.children[j];
+                        if(child.type !== 'dir' && new RegExp("index.html$").test(child.path) ){
+                                siblings[i] = child;
+                                siblings[i].children = node.children;
+                                node.children.splice(j,1);
+                                break;
+                        }
+                    }
+                }
+            }
+    
+            // recurse children
+            for(var i = siblings.length - 1; i >= 0; i--){
+                var node = siblings[i];
+                if(node.children){
+                    merge(node.children);
+                }
+            }
+        };
+    
+        merge(tree);
+        return tree;
+    };
+    
+/**
 * @method setFileObjectReferences
 * @param {Array} tree - nav node tree
 * @param {Object} files - Metalsmith files object
@@ -487,6 +529,7 @@ var getNav = function(navName, config, navFiles, settings, metadata){
         sortBy                      = config.sortBy,
         breadcrumbProperty          = config.breadcrumbProperty,
         pathProperty                = config.pathProperty,
+        mergeIndexWithParentDir     = config.mergeIndexWithParentDir,
         mergeMatchingFilesAndDirs   = config.mergeMatchingFilesAndDirs,
         includeDirs                 = config.includeDirs,
         childrenProperty            = config.childrenProperty,
@@ -512,6 +555,10 @@ var getNav = function(navName, config, navFiles, settings, metadata){
 
     if(mergeMatchingFilesAndDirs){
         nodes = mergeFileDirs(nodes);
+    }
+
+    if(mergeIndexWithParentDir){
+        nodes = mergeIndexWithDir(nodes);
     }
 
     if(sortByNameFirst){

--- a/lib/index.js
+++ b/lib/index.js
@@ -119,7 +119,7 @@ var NAV_CONFIG_DEFAULT = {
     prepareNodeMetadata: false,
 
     /*
-    * shoudl be set to true if you are using plugin metalsmith-clean-urls
+    * should be set to true if you are using plugin metalsmith-clean-urls
     */
     cleanUrls: false
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -117,6 +117,11 @@ var NAV_CONFIG_DEFAULT = {
     * function example: function(navNode, metadata){ navNode.title = "test"; }
     */
     prepareNodeMetadata: false,
+
+    /*
+    * shoudl be set to true if you are using plugin metalsmith-clean-urls
+    */
+    cleanUrls: false
 };
 
 /**
@@ -301,6 +306,7 @@ var mergeFileDirs = function(tree){
     var merge = function(siblings){
         for (var i = siblings.length - 1; i >= 0; i--){
             var node = siblings[i];
+            console.log(node)
             if(node.type === 'dir'){
                 for(var j = siblings.length - 1; j >= 0; j--){
                     var sibling = siblings[j];
@@ -534,7 +540,8 @@ var getNav = function(navName, config, navFiles, settings, metadata){
         includeDirs                 = config.includeDirs,
         childrenProperty            = config.childrenProperty,
         filterProperty              = config.filterProperty,
-        filterValue                 = config.filterValue || navName;
+        filterValue                 = config.filterValue || navName,
+        cleanUrls                   = config.cleanUrls;
 
     settings = settings || {};
 
@@ -553,13 +560,21 @@ var getNav = function(navName, config, navFiles, settings, metadata){
 
     nodes = addNodeMetadata(nodes, navFiles, config, metadata);
 
-    if(mergeMatchingFilesAndDirs){
-        nodes = mergeFileDirs(nodes);
+    if(cleanUrls){
+        if(mergeIndexWithParentDir || mergeMatchingFilesAndDirs){
+            nodes = mergeIndexWithDir(nodes);
+        }
+    }
+    else {
+        if(mergeMatchingFilesAndDirs){
+            nodes = mergeFileDirs(nodes);
+        }        
+        
+        if(mergeIndexWithParentDir){
+            nodes = mergeIndexWithDir(nodes);
+        }
     }
 
-    if(mergeIndexWithParentDir){
-        nodes = mergeIndexWithDir(nodes);
-    }
 
     if(sortByNameFirst){
         nodes = sortNodes(nodes, function(node){

--- a/lib/index.js
+++ b/lib/index.js
@@ -306,7 +306,6 @@ var mergeFileDirs = function(tree){
     var merge = function(siblings){
         for (var i = siblings.length - 1; i >= 0; i--){
             var node = siblings[i];
-            console.log(node)
             if(node.type === 'dir'){
                 for(var j = siblings.length - 1; j >= 0; j--){
                     var sibling = siblings[j];
@@ -361,10 +360,10 @@ var mergeIndexWithDir = function(tree){
                     for(var j = node.children.length - 1; j >= 0; j--){
                         var child = node.children[j];
                         if(child.type !== 'dir' && new RegExp("index.html$").test(child.path) ){
-                                siblings[i] = child;
-                                siblings[i].children = node.children;
-                                node.children.splice(j,1);
-                                break;
+                            siblings[i] = child;
+                            siblings[i].children = node.children;
+                            node.children.splice(j,1);
+                            break;
                         }
                     }
                 }


### PR DESCRIPTION
option **cleanurls** is defaultly set to false. it should be set to true if you are using plugin metalsmith-clean-urls

**mergeIndexWithParentDir** find index.md in folder and merge it with parent folder. it is used also because
plugin metalsmith-clean-urls